### PR TITLE
Add example widget in message box which allows sending rich messages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { Route } from 'wouter';
 import CustomerDetailsWidget from './pages/customer-details-widget/CustomerDetailsWidget';
 import './App.css';
+import MessageBoxWidget from './pages/messagebox-widget/MessageBoxWidget';
 
 function App(): JSX.Element {
   return (
     <div className="App">
       <Route path="/pages/customer-details-widget" component={CustomerDetailsWidget} />
+      <Route path="/pages/message-box-widget" component={MessageBoxWidget} />
       <Route path="/pages/test1">test1</Route>
     </div>
   );

--- a/src/pages/messagebox-widget/MessageBoxWidget.tsx
+++ b/src/pages/messagebox-widget/MessageBoxWidget.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { FieldGroup, RadioButton } from '@livechat/design-system';
+import { createMessageBoxWidget, IMessageBoxWidget } from '@livechat/agent-app-sdk';
+import '@livechat/design-system/dist/design-system.css';
+import templates, { Template } from './message-templates';
+
+export default function MessageBoxWidget(): React.ReactElement {
+  const [widgetInstance, setWidgetInstance] = useState<IMessageBoxWidget | null>(null);
+  const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null);
+
+  useEffect(() => {
+    createMessageBoxWidget().then((messageBoxWidget: IMessageBoxWidget) => {
+      setWidgetInstance(messageBoxWidget);
+    });
+  }, []);
+
+  useEffect(() => {
+    const foundTemplate = templates.find((template) => template.id === selectedTemplate);
+    if (foundTemplate) {
+      widgetInstance?.putMessage(foundTemplate.message);
+    }
+  }, [selectedTemplate]);
+
+  const onRadioChange = (id: string) => {
+    setSelectedTemplate(id);
+  };
+
+  const radioButtons = templates.map((template: Template) => (
+    <RadioButton
+      id={template.id}
+      checked={selectedTemplate === template.id}
+      value={template.id}
+      onChange={() => onRadioChange(template.id)}
+      key={template.id}
+    >
+      {template.label}
+    </RadioButton>
+  ));
+  return (
+    <div style={{ margin: '0.8rem' }}>
+      <FieldGroup>{...radioButtons}</FieldGroup>
+    </div>
+  );
+}

--- a/src/pages/messagebox-widget/message-templates.ts
+++ b/src/pages/messagebox-widget/message-templates.ts
@@ -1,0 +1,128 @@
+import { IRichMessage } from '@livechat/agent-app-sdk';
+
+export interface Template {
+  label: string;
+  id: string;
+  message: IRichMessage;
+}
+const richWithImage: IRichMessage = {
+  template_id: 'cards',
+  elements: [
+    {
+      title: 'Rich message with an image',
+      subtitle: 'this is subtitle',
+      image: {
+        url: 'https://www.livechat.com/livechat-agents.5dc134d1bce1a7e12ff409533d9abf2662c2761458a567fbc4506bceba138ba2.svg',
+      },
+    },
+  ],
+};
+
+const carousel: IRichMessage = {
+  template_id: 'cards',
+  elements: [
+    {
+      title: 'Tomatoes',
+      subtitle:
+        'The tomato is the edible, often red, berry of the plant Solanum lycopersicum, commonly known as a tomato plant. They are also very tasty!',
+      image: {
+        url: 'https://images.pexels.com/photos/1327838/pexels-photo-1327838.jpeg',
+      },
+      buttons: [
+        {
+          type: 'url',
+          text: 'Open link',
+          postback_id: 'open_url',
+          user_ids: [],
+          value: 'https://example.org/?product1',
+        },
+      ],
+    },
+    {
+      title: 'Cucumber',
+      subtitle:
+        'There are three main varieties of cucumber: slicing, pickling, and seedless. Within these varieties, several cultivars have been created.',
+      image: {
+        url: 'https://images.pexels.com/photos/37528/cucumber-salad-food-healthy-37528.jpeg',
+      },
+      buttons: [
+        {
+          type: 'url',
+          text: 'Open link',
+          postback_id: 'open_url',
+          user_ids: [],
+          value: 'https://example.org/?product2',
+        },
+      ],
+    },
+    {
+      title: 'Potatoe',
+      subtitle:
+        'Potatoe is a root vegetable, very popular around the world. With the potatoe, you can do a lot, for example prepare awesome french fries.',
+      image: {
+        url: 'https://images.pexels.com/photos/144248/potatoes-vegetables-erdfrucht-bio-144248.jpeg',
+      },
+      buttons: [
+        {
+          type: 'url',
+          text: 'Open link',
+          postback_id: 'open_url',
+          user_ids: [],
+          value: 'https://example.org/?product3',
+        },
+      ],
+    },
+  ],
+};
+
+const quickReplies: IRichMessage = {
+  template_id: 'quick_replies',
+  elements: [
+    {
+      title: 'What OS are you using?',
+      buttons: [
+        {
+          type: 'message',
+          text: 'Windows',
+          postback_id: 'send_message',
+          user_ids: [],
+          value: 'Windows',
+        },
+        {
+          type: 'message',
+          text: 'MacOS',
+          postback_id: 'send_message',
+          user_ids: [],
+          value: 'MacOS',
+        },
+        {
+          type: 'message',
+          text: 'Other',
+          postback_id: 'send_message',
+          user_ids: [],
+          value: 'Other',
+        },
+      ],
+    },
+  ],
+};
+
+const templates: Template[] = [
+  {
+    label: 'Rich message with image and button',
+    id: 'rich-message',
+    message: richWithImage,
+  },
+  {
+    label: 'Carousel',
+    id: 'carousel',
+    message: carousel,
+  },
+  {
+    label: 'Quick replies',
+    id: 'quick-replies',
+    message: quickReplies,
+  },
+];
+
+export default templates;


### PR DESCRIPTION
![Screenshot 2021-08-13 at 10 14 01](https://user-images.githubusercontent.com/58426925/129327526-1f87c5e8-da45-446d-9b8b-ff91360ba4d3.png)
Addresses https://github.com/livechat/agent-app-widgets-example/issues/8
Simple widget with radio buttons. Radio button selects rich message template which is then applied to `putMessage` method from messagebox widget API.