### PR TITLE
Fix typescript errors

### DIFF
--- a/src/components/permissions/Permissions.tsx
+++ b/src/components/permissions/Permissions.tsx
@@ -15,7 +15,11 @@ export default function Permissions(): React.ReactElement {
   const requestMicAndCamera = () => {
     navigator.getUserMedia(
       { video: true, audio: true },
-      (stream: MediaStream) => (videoElement.current.srcObject = stream),
+      (stream: MediaStream) => {
+        if (videoElement.current) {
+          videoElement.current.srcObject = stream;
+        }
+      },
       (videoError: MediaStreamError) => setError(videoError.message)
     );
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,


### PR DESCRIPTION
In order to have working production build I had to
- exclude dependencies from being type-checked when `tsc`
- fix error with possible null value